### PR TITLE
Added google calendar link to sync up with Pydelhi Calender on google calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
           href="http://bit.ly/pydelhi-google" target=blank rel=external>Google Plus</a>
           <ul>
             <li><a title='Join us on our Google plus community' href="http://bit.ly/pydelhi-google" target=blank rel=external>Join Us</a></li>
-            <li><a title='Sync up with our Google Calender' href="https://www.google.com/calendar/embed?src=pythondelhi%40gmail.com&ctz=Asia/Calcutta" target="_blank" rel=external></a>Google Calender</li>
+            <li><a title='Sync up with our Google Calender' href="https://www.google.com/calendar/embed?src=pythondelhi%40gmail.com&ctz=Asia/Calcutta" target="_blank" rel=external>Google Calender</a></li>
           </ul>
           </li>
         <li><a title='Follow us on Twitter for updates'

--- a/index.html
+++ b/index.html
@@ -36,7 +36,12 @@
         <li><a title='Join us on our Facebook Group'
            href="http://bit.ly/pydelhi-facebook" target=blank rel=external>Facebook</a></li>
         <li><a title='Join us on our Google plus community'
-          href="http://bit.ly/pydelhi-google" target=blank rel=external>Google Plus</a></li>
+          href="http://bit.ly/pydelhi-google" target=blank rel=external>Google Plus</a>
+          <ul>
+            <li><a title='Join us on our Google plus community' href="http://bit.ly/pydelhi-google" target=blank rel=external>Join Us</a></li>
+            <li><a title='Sync up with our Google Calender' href="https://www.google.com/calendar/embed?src=pythondelhi%40gmail.com&ctz=Asia/Calcutta" target="_blank" rel=external></a>Google Calender</li>
+          </ul>
+          </li>
         <li><a title='Follow us on Twitter for updates'
            href="http://bit.ly/pydelhi-twitter" target=blank rel=external>Twitter</a>
             <ul>


### PR DESCRIPTION
Maybe a overkill but helps in having a central place following can be done:
- Creating and syncing up community activities with google calendar seamlessly just takes one click to import it to your calendar.
- Create repeating events like hangout session from central location then adding through personal google calendar.
