### PR TITLE
Remove Telegram Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,6 @@
             <li><a href="https://bit.ly/pydelhi-irc" target="_blank" rel=external>IRC Web</a></li>
             <li><a href="https://botbot.me/irc-guide/" target="_blank" rel=external>IRC Guide</a></li>
             <li><a href="https://bit.ly/pydelhi-irclogs" target="_blank" rel=external>IRC Logs</a></li>
-            <li><a href="https://t.me/joinchat/AAAAAEK2nzPg0IlwbbAing" target="_blank" rel=external>Telegram <small>for Volunteers</small></a></li>
           </ul>
         </li>
         <li><a title='Videos at PyDelhi' href="#" onclick="return false;">Videos</a>


### PR DESCRIPTION
Since the telegram link is non functioning it makes sense to remove it.